### PR TITLE
Fix USP email address

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -49,7 +49,7 @@ address:
     - 05508-080 - São Paulo – SP – Brazil
     - 23°33’42.48”S, 46°43’39.87”W
 
-email: camila.viana@usp.com
+email: camila.viana@usp.br
 tel: +55 11 3091 4242
 
 


### PR DESCRIPTION
It was ending in `usp.com` instead of `usp.br`.